### PR TITLE
Remove Travis build status from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Apache Fineract CN Teller [![Build Status](https://api.travis-ci.com/apache/fineract-cn-teller.svg?branch=develop)](https://travis-ci.com/apache/fineract-cn-teller)  [![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/apache/fineract-cn-teller)](https://hub.docker.com/r/apache/fineract-cn-teller/builds)
+# Apache Fineract CN Teller [![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/apache/fineract-cn-teller)](https://hub.docker.com/r/apache/fineract-cn-teller/builds)
 
 This project provides management and operational functionality for teller operation.
 [Read more](https://cwiki.apache.org/confluence/display/FINERACT/Fineract+CN+Project+Structure#FineractCNProjectStructure-teller).


### PR DESCRIPTION
Due to the removal of the Travis build scripts from the project. The build status in the README.md is now misleading and needs to be removed.